### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -4,8 +4,8 @@ f_c	KEYWORD2
 msToKmh	KEYWORD2
 msToMph	KEYWORD2
 msToKn	KEYWORD2
-m_f KEYWORD2
-f_m KEYWORD2
+m_f	KEYWORD2
+f_m	KEYWORD2
 humidex_c	KEYWORD2
 humidex_f	KEYWORD2
 dewPoint_c	KEYWORD2
@@ -18,6 +18,6 @@ heatIndex_f	KEYWORD2
 apparentTemp_c	KEYWORD2
 apparentTemp_f	KEYWORD2
 cloudBase_m	KEYWORD2
-cloudBase_f KEYWORD2
-relativePressure_c KEYWORD2
-relativePressure_f KEYWORD2
+cloudBase_f	KEYWORD2
+relativePressure_c	KEYWORD2
+relativePressure_f	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords